### PR TITLE
symlink autoi

### DIFF
--- a/bin/autoinstall
+++ b/bin/autoinstall
@@ -2,6 +2,17 @@
 
 var autoinstall = require.resolve('..')
 
+var fs = require('fs')
+var path = require('path')
+
+fs.exists(path.dirname(process.execPath)+'/autoi',
+  function (exists) {
+    if(!exists)
+      fs.symlink(process.mainModule.filename,
+      path.dirname(process.execPath)+'/autoi',
+      function (err) { if(err)throw err } )
+});
+
 var args = process.argv.slice(2)
 
 var options = []
@@ -17,7 +28,6 @@ if (args.length > 1) {
   throw new Error('more than 1 argument supplied')
 }
 
-var path = require('path')
 var file = path.resolve(args[0])
 
 options.push('-e',


### PR DESCRIPTION
fixes issue https://github.com/normalize/autoinstall/issues/4. autoinstall global checks for autoi link. it adds the symbolic link if needed. 

run autoinstall once and from there on out you got autoi
